### PR TITLE
revert xxd to od, trim newlines

### DIFF
--- a/yubitouch.sh
+++ b/yubitouch.sh
@@ -73,7 +73,7 @@ fi
 
 PIN_LEN=${#PIN}
 
-PIN=$(echo -n "$PIN" | od -A n -t x1 --width=$PIN_LEN)
+PIN=$(echo -n "$PIN" | xxd -ps | tr -d '\n')
 
 PIN_LEN=$(printf %02x $PIN_LEN)
 


### PR DESCRIPTION
The `od` that ships with macOS (current as of Sierra) doesn't support the `--width` parameter.

This change switches back to `xxd` but trims out newlines.

Noting that `xxd` does support a `cols` parameter however it is limited to 256. Trimming newlines enables arbitrarily long strings.
