### PR TITLE
Add new parameter all to apply an action to all keys

### DIFF
--- a/README.org
+++ b/README.org
@@ -21,13 +21,13 @@ its smaller surface / fewer dependencies.
 
 Run the tool as:
 #+BEGIN_SRC sh
-./yubitouch.sh {sig|aut|dec} {get|off|on|fix|cacheon|cachefix} [admin_pin]
+./yubitouch.sh {all|sig|aut|dec} {get|off|on|fix|cacheon|cachefix} [admin_pin]
 #+END_SRC
 
 where the parameters indicate the following:
 
 #+BEGIN_EXAMPLE
- {sig|aut|dec|att} Signature, authentication, decryption or attestation key
+ {all|sig|aut|dec|att} All keys, signature, authentication, decryption or attestation key
  {get|off|on|fix|cacheon|cachefix} Touch setting to use
  [admin_pin] The Admin PIN of the YubiKey (optional)
 #+END_EXAMPLE
@@ -36,6 +36,7 @@ where the parameters indicate the following:
 
 The four possible values for the key parameter are explained below.
 
+- all :: Loop over all keys
 - sig :: Key used for digital signatures
 - aut :: Key used for authentication (e.g. SSH)
 - dec :: Key used for decryption
@@ -81,7 +82,8 @@ mindful of having sensitive data stored in your shell history*.
 
 If the Admin PIN is not provided through the command line, the tool
 will ask the user for it. If a version of ~pinentry~ is available it
-will be used, otherwise it will fall back to reading standard input.
+will be used, otherwise it will fall back to reading standard input. If all is
+used for the key parameter then the tool will ask the user only once for it.
 
 ** Personalization advice
 

--- a/yubitouch.sh
+++ b/yubitouch.sh
@@ -41,126 +41,139 @@ fi
 if [ $# -lt 2 ] || [ $# -gt 3 ]
 then
     echo "Wrong parameters" >&2
-    echo "usage: yubitouch {sig|aut|dec|att} {get|off|on|fix|cacheon|cachefix} [admin_pin]" >&2
+    echo "usage: yubitouch {all|sig|aut|dec|att} {get|off|on|fix|cacheon|cachefix} [admin_pin]" >&2
     exit 1;
 fi
 
-if [ "$1" = "sig" ]
+
+if [ "$1" = "all" ]
 then
-    DO="D6"
-elif [ "$1" = "dec" ]
-then
-    DO="D7"
-elif [ "$1" = "aut" ]
-then
-    DO="D8"
-elif [ "$1" = "att" ]
-then
-    DO="D9"
+    Keys="sig dec aut att"
 else
-    echo "Invalid value $1 (must be sig, aut, dec, att). Aborting..." >&2
-    exit 1
+    Keys=$1
 fi
 
-if [ "$2" = "get" ]
-then
+for k in $Keys; do
+    if [ "$k" = "sig" ]
+    then
+        DO="D6"
+    elif [ "$k" = "dec" ]
+    then
+        DO="D7"
+    elif [ "$k" = "aut" ]
+    then
+        DO="D8"
+    elif [ "$k" = "att" ]
+    then
+        DO="D9"
+    else
+        echo "Invalid key value '$k' (must be sig, aut, dec, att). Aborting..." >&2
+        exit 1
+    fi
+
+    if [ "$2" = "get" ]
+    then
+        "$GCA" --hex "scd reset" /bye > /dev/null
+
+        GET=$("$GCA" --hex "scd apdu 00 ca 00 $DO 00" /bye)
+        if ! echo "$GET" | grep -q "90 00"
+        then
+            echo "Get data failed for $k, unsupported device?" >&2
+            exit 1
+        fi
+
+        STATUS=$(echo "$GET" | grep -oE "[0-9]{2} 20 90 00" | cut -c 1-2)
+
+        if [ "$STATUS" = "00" ]
+        then
+            UIF="off"
+        elif [ "$STATUS" = "01" ]
+        then
+            UIF="on"
+        elif [ "$STATUS" = "02" ]
+        then
+            UIF="fix"
+        elif [ "$STATUS" = "03" ]
+        then
+            UIF="cacheon"
+        elif [ "$STATUS" = "04" ]
+        then
+            UIF="cachefix"
+        else
+            echo "Unknown touch setting status ($STATUS)" >&2
+            exit 1
+        fi
+
+        echo "Current $k touch setting: $UIF" >&2
+        continue
+    elif [ "$2" = "off" ]
+    then
+        UIF="00";
+    elif [ "$2" = "on" ]
+    then
+        UIF="01"
+    elif [ "$2" = "fix" ]
+    then
+        UIF="02";
+    elif [ "$2" = "cacheon" ]
+    then
+        UIF="03";
+    elif [ "$2" = "cachefix" ]
+    then
+        UIF="04";
+    else
+        echo "Invalid value $2 (must be get, off, on, fix, cacheon, cachefix). Aborting..." >&2
+        exit 1
+    fi
+
+    echo "Processing key $k with action $2"
+
+    if [ $# -eq 3 ] && [ -z "$PIN" ]
+    then
+        PIN="$3"
+    elif [ -z "$PE" ] && [ -z "$PIN" ]
+    then
+        echo "Pinentry not present" >&2
+        echo "Falling back to regular stdin." >&2
+        echo "Be careful!" >&2
+        echo "Enter your admin PIN: "
+        read -r PIN
+    elif [ -z "$PIN" ]
+    then
+        CURRENT_TTY=$(tty)
+        # shellcheck disable=SC2059
+        PIN=$(printf "$PE_PROMPT" | $PE --ttyname "$CURRENT_TTY" | sed -n '/^D .*/s/^D //p')
+    fi
+
+    if [ -z "$PIN" ]
+    then
+        echo "Empty PIN. Aborting..." >&2
+        exit 1
+    fi
+
+    PIN_LEN=${#PIN}
+
+    # shellcheck disable=SC2059
+    PIN_HEX=$(printf "$PIN" | ascii_to_hex | tr -d '\n')
+
+    PIN_LEN_HEX=$(printf %02x "$PIN_LEN")
+
     "$GCA" --hex "scd reset" /bye > /dev/null
 
-    GET=$("$GCA" --hex "scd apdu 00 ca 00 $DO 00" /bye)
-    if ! echo "$GET" | grep -q "90 00"
+    VERIFY=$("$GCA" --hex "scd apdu 00 20 00 83 $PIN_LEN_HEX $PIN_HEX" /bye)
+    if ! echo "$VERIFY" | grep -q "90 00"
     then
-        echo "Get data failed, unsupported device?" >&2
+        echo "Verification failed, wrong pin?" >&2
         exit 1
     fi
 
-    STATUS=$(echo "$GET" | grep -oE "[0-9]{2} 20 90 00" | cut -c 1-2)
-
-    if [ "$STATUS" = "00" ]
+    PUT=$("$GCA" --hex "scd apdu 00 da 00 $DO 02 $UIF 20" /bye)
+    if ! echo "$PUT" | grep -q "90 00"
     then
-        UIF="off"
-    elif [ "$STATUS" = "01" ]
-    then
-        UIF="on"
-    elif [ "$STATUS" = "02" ]
-    then
-        UIF="fix"
-    elif [ "$STATUS" = "03" ]
-    then
-        UIF="cacheon"
-    elif [ "$STATUS" = "04" ]
-    then
-        UIF="cachefix"
-    else
-        echo "Unknown touch setting status ($STATUS)" >&2
+        echo "Unable to change mode for key $k. Set to fix?" >&2
         exit 1
     fi
-
-    echo "Current $1 touch setting: $UIF" >&2
-    exit 0
-elif [ "$2" = "off" ]
-then
-    UIF="00";
-elif [ "$2" = "on" ]
-then
-    UIF="01"
-elif [ "$2" = "fix" ]
-then
-    UIF="02";
-elif [ "$2" = "cacheon" ]
-then
-    UIF="03";
-elif [ "$2" = "cachefix" ]
-then
-    UIF="04";
-else
-    echo "Invalid value $2 (must be get, off, on, fix, cacheon, cachefix). Aborting..." >&2
-    exit 1
-fi
-
-if [ $# -eq 3 ]
-then
-    PIN="$3"
-elif [ -z "$PE" ]
-then
-    echo "Pinentry not present" >&2
-    echo "Falling back to regular stdin." >&2
-    echo "Be careful!" >&2
-    echo "Enter your admin PIN: "
-    read -r PIN
-else
-    CURRENT_TTY=$(tty)
-    # shellcheck disable=SC2059
-    PIN=$(printf "$PE_PROMPT" | $PE --ttyname "$CURRENT_TTY" | sed -n '/^D .*/s/^D //p')
-fi
-
-if [ -z "$PIN" ]
-then
-    echo "Empty PIN. Aborting..." >&2
-    exit 1
-fi
-
-PIN_LEN=${#PIN}
-
-# shellcheck disable=SC2059
-PIN=$(printf "$PIN" | ascii_to_hex | tr -d '\n')
-
-PIN_LEN=$(printf %02x "$PIN_LEN")
-
-"$GCA" --hex "scd reset" /bye > /dev/null
-
-VERIFY=$("$GCA" --hex "scd apdu 00 20 00 83 $PIN_LEN $PIN" /bye)
-if ! echo "$VERIFY" | grep -q "90 00"
-then
-    echo "Verification failed, wrong pin?" >&2
-    exit 1
-fi
-
-PUT=$("$GCA" --hex "scd apdu 00 da 00 $DO 02 $UIF 20" /bye)
-if ! echo "$PUT" | grep -q "90 00"
-then
-    echo "Unable to change mode. Set to fix?" >&2
-    exit 1
-fi
+done
 
 echo "All done!"
 exit 0


### PR DESCRIPTION
Add simple loop to allow manipulating all keys with the given action at once for convenience, reading or setting the keys. PIN is only asked once and each subsequent prompt is suppressed.

* Add new parameter "all" which allows looping over all keys for a given action, otherwise use the provided key as it is.
* Change PIN to PIN_HEX and PIN_LEN to PIN_LEN_HEX, therefore the PIN entry from first loop round can be used for all the subsequent runs. Otherwise, the PIN to HEX conversion would be done multiple time and the admin pin becomes unusable after first round.
* Use continue instead of exit at the end of get section.
* Improved error logs by adding the key to the message.
* Update usage info.
* Update README to reflect those changes.